### PR TITLE
z相分の配列の追加

### DIFF
--- a/cubic_arduino/cubic_arduino.cpp
+++ b/cubic_arduino/cubic_arduino.cpp
@@ -6,7 +6,7 @@ SPISettings ADC_SPISettings = SPISettings(ADC_SPI_FREQ, MSBFIRST, SPI_MODE0);
 const uint8_t Adc::ch[DC_MOTOR_NUM] = {7, 5, 6, 4, 3, 2, 0, 1};
 
 int16_t DC_motor::buf[(DC_MOTOR_NUM+SOL_SUB_NUM)*2];
-uint8_t Inc_enc::buf[INC_ENC_NUM*INC_ENC_BYTES];
+uint8_t Inc_enc::buf[INC_ENC_NUM*INC_ENC_BYTES*2];
 uint8_t Abs_enc::buf[ABS_ENC_NUM*ABS_ENC_BYTES];
 float Adc::buf[DC_MOTOR_NUM];
 
@@ -181,7 +181,7 @@ void Inc_enc::begin(void){
 }
 
 int32_t Inc_enc::get(const uint8_t num){
-    if(num >= INC_ENC_NUM) return 1;
+    if(num >= INC_ENC_NUM*2) return 1;
 
     int32_t ret = 0;
     ret |= buf[num*INC_ENC_BYTES];
@@ -208,7 +208,7 @@ void Inc_enc::receive(void){
 
     SPI.beginTransaction(Cubic_SPISettings);
     // データを受信
-    for (int i = 0; i < INC_ENC_NUM*INC_ENC_BYTES; i++) {
+    for (int i = 0; i < INC_ENC_NUM*INC_ENC_BYTES*2; i++) {
         digitalWriteFast(Pin(SS_INC_ENC),LOW);
         buf[i] = SPI.transfer(0x88);
         digitalWriteFast(Pin(SS_INC_ENC),HIGH);
@@ -223,7 +223,7 @@ void Inc_enc::reset(void){
 }
 
 void Inc_enc::print(const bool new_line){
-    for (int i = 0; i < INC_ENC_NUM; i++) {
+    for (int i = 0; i < INC_ENC_NUM*2; i++) {
         Serial.print(get(i));
         Serial.print(" ");
     }

--- a/cubic_arduino/cubic_arduino.h
+++ b/cubic_arduino/cubic_arduino.h
@@ -160,7 +160,7 @@ class Inc_enc{
 
     private:
         // RP2040からの受信データを格納する配列
-        static uint8_t buf[INC_ENC_NUM*INC_ENC_BYTES];
+        static uint8_t buf[INC_ENC_NUM*INC_ENC_BYTES*2];
 
         // 1つ前の値を格納する配列
         static int32_t val_prev[INC_ENC_NUM];


### PR DESCRIPTION
RP2040でインクリメントエンコーダのZ相を読み込むために配列の長さを2倍にした。